### PR TITLE
Tag as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dombarsify
 
+![This plugin is deprecated](http://messages.hellobits.com/warning.svg?message=This%20plugin%20is%20deprecated!)
+
 [DOMBars](https://github.com/blakeembrey/dombars) pre-compilation plugin for [Browserify](https://github.com/substack/node-browserify). Compiles DOMBars/Handlebars templates into plain JavaScript. All compiled templates include only the DOMBars runtime and the precompiled template, so they are several factors faster and lightweight than including and parsing the original template.
 
 ## Usage


### PR DESCRIPTION
DOMBars is tagged as deprecated, this plugin shoud be tagged as
deprecated too.
